### PR TITLE
ビューにて表示変更

### DIFF
--- a/app/views/time_content/new.html.erb
+++ b/app/views/time_content/new.html.erb
@@ -12,7 +12,11 @@
 
   <div class="time_and_content">
     <div class="date">
-      <%= f.date_field :start_time, value: Date.today, class: "date_style"  %>
+      <% if @time_content.start_time == nil %>
+        <%= f.date_field :start_time, value: Date.today, class: "date_style"  %>
+      <% elsif @time_content.start_time != nil %>
+        <%= f.date_field :start_time, class: "date_style"  %>
+      <% end %>
     </div>
 
     <div class="time"> 


### PR DESCRIPTION
条件分岐にて設定は当日の日付を入れているが、日付を変更し、
登録内容に誤りがあった場合、日付が当日の日付に戻らないように変更